### PR TITLE
feat: 댓글 API 권한 처리 및 목록 기능 완료

### DIFF
--- a/src/main/kotlin/com/sideproject/userInfo/userInfo/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/sideproject/userInfo/userInfo/config/SecurityConfig.kt
@@ -15,7 +15,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 class SecurityConfig {
     @Bean
     fun SecurityFilterChain(
@@ -25,7 +25,9 @@ class SecurityConfig {
         http
             .csrf { it.disable() }
             .authorizeHttpRequests { auth ->
-                auth.requestMatchers("/", "/auth/**", "/admin/auth/**", "/movies").permitAll()
+                auth.requestMatchers(
+                    "/", "/auth/**", "/admin/auth/**", "/movies", "/api/users/comments"
+                ).permitAll()
                     .requestMatchers("/admin/users/**", "/admin/my").hasRole("ADMIN")
                     .anyRequest().authenticated()
             }

--- a/src/main/kotlin/com/sideproject/userInfo/userInfo/controller/CommentController.kt
+++ b/src/main/kotlin/com/sideproject/userInfo/userInfo/controller/CommentController.kt
@@ -5,11 +5,11 @@ import com.sideproject.userInfo.userInfo.data.dto.services.CommentRequest
 import com.sideproject.userInfo.userInfo.data.dto.services.CommentResponseDto
 import com.sideproject.userInfo.userInfo.service.AuthService
 import com.sideproject.userInfo.userInfo.service.CommentService
-import io.lettuce.core.GeoArgs.Sort
 import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.*
 
@@ -28,6 +28,7 @@ class CommentController(
         return ResponseEntity.ok(commentService.getCommentList(pageable, date))
     }
 
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/comments")
     fun createComment(
         @RequestBody @Valid

--- a/src/main/kotlin/com/sideproject/userInfo/userInfo/controller/CommentController.kt
+++ b/src/main/kotlin/com/sideproject/userInfo/userInfo/controller/CommentController.kt
@@ -2,9 +2,13 @@ package com.sideproject.userInfo.userInfo.controller
 
 import com.sideproject.userInfo.userInfo.common.response.RestResponse
 import com.sideproject.userInfo.userInfo.data.dto.services.CommentRequest
+import com.sideproject.userInfo.userInfo.data.dto.services.CommentResponseDto
 import com.sideproject.userInfo.userInfo.service.AuthService
 import com.sideproject.userInfo.userInfo.service.CommentService
+import io.lettuce.core.GeoArgs.Sort
 import jakarta.validation.Valid
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.*
@@ -17,8 +21,11 @@ class CommentController(
     private val authService: AuthService,
 ) {
     @GetMapping("/comments")
-    fun getCommentList(date: String): ResponseEntity<RestResponse<Map<String, Any>>> {
-        return ResponseEntity.ok(commentService.getCommentList(date))
+    fun getCommentList(
+        @PageableDefault(size = 10) pageable: Pageable,
+        date: String
+    ): ResponseEntity<CommentResponseDto> {
+        return ResponseEntity.ok(commentService.getCommentList(pageable, date))
     }
 
     @PostMapping("/comments")

--- a/src/main/kotlin/com/sideproject/userInfo/userInfo/data/dto/services/CommentResponseDto.kt
+++ b/src/main/kotlin/com/sideproject/userInfo/userInfo/data/dto/services/CommentResponseDto.kt
@@ -1,0 +1,37 @@
+package com.sideproject.userInfo.userInfo.data.dto.services
+
+import com.sideproject.userInfo.userInfo.data.entity.CommentEntity
+import java.time.LocalDateTime
+
+class CommentResponseDto(
+    val comment: List<CommentsDto>,
+    val pageInfo: PageInfoDto
+)
+
+class CommentsDto(
+    val userId: Long?,
+    val nickName: String,
+    val content: String,
+    val targetDate: String,
+    val createdAt: LocalDateTime? = null,
+) {
+    companion object {
+        fun fromEntity(commentEntity: CommentEntity): CommentsDto {
+            return CommentsDto(
+                commentEntity.user.id,
+                commentEntity.user.nickName,
+                commentEntity.content,
+                commentEntity.targetDate.toString(),
+                commentEntity.createdAt,
+            )
+        }
+    }
+}
+
+class PageInfoDto(
+    val date: String,
+    val pageNumber: Int,
+    val pageSize: Int,
+    val totalElements: Long,
+    val totalPages: Int
+)

--- a/src/main/kotlin/com/sideproject/userInfo/userInfo/repository/CommentRepository.kt
+++ b/src/main/kotlin/com/sideproject/userInfo/userInfo/repository/CommentRepository.kt
@@ -1,8 +1,13 @@
 package com.sideproject.userInfo.userInfo.repository
 
 import com.sideproject.userInfo.userInfo.data.entity.CommentEntity
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 
 @Repository
-interface CommentRepository : JpaRepository<CommentEntity, Long>
+interface CommentRepository : JpaRepository<CommentEntity, Long> {
+    fun findByTargetDate(targetDate: LocalDate, pageable: Pageable): Page<CommentEntity>
+}


### PR DESCRIPTION
- 댓글 목록 조회 기능 완료
- createComment()에 @PreAuthorize 추가로 인증 처리 적용
- /api/users/comments 엔드포인트에 permitAll() 적용하여 공개 접근 허용